### PR TITLE
fix(tpcc-driver): Fixed buffer overflow error on Ubuntu 24.04 (MAX_ITEM_LEN 24 → 25)

### DIFF
--- a/src/tpc.h
+++ b/src/tpc.h
@@ -29,7 +29,9 @@ extern "C" {
 
 /* definitions for new order transaction */
 #define MAX_NUM_ITEMS 15
-#define MAX_ITEM_LEN  24
+/* Row size must accommodate i_name[25] (VARCHAR(24) + NUL) copied by
+ * strncpy(iname[idx], i_name, 25) in neword.c. */
+#define MAX_ITEM_LEN  25
 
 #define swap_int(a,b) {int tmp; tmp=a; a=b; b=tmp;}
 


### PR DESCRIPTION
## Symptom

On Ubuntu 24.04 / glibc 2.39, `tpcc_start` aborts during RAMP-UP with:

```
*** buffer overflow detected ***: terminated
```
before any transaction completes. The same driver ran fine for years on Ubuntu 14.04 / MySQL 5.x.

## Root cause

- `src/neword.c:339` always wrote 25 bytes into a 24-byte row:
  ```c
  // src/tpc.h (pre-fix)
  #define MAX_ITEM_LEN  24

  // src/neword.c:87
  char iname[MAX_NUM_ITEMS][MAX_ITEM_LEN];   // rows are 24 bytes

  // src/neword.c:339
  strncpy(iname[ol_num_seq[ol_number - 1]], i_name, 25);  // writes 25
  ```
- `strncpy(dst, src, n)` always writes exactly `n` bytes (C11 §7.24.2.4), so this is a 1-byte out-of-bounds write on every new-order transaction.
- The source `char i_name[25]` (neword.c:65) is correctly sized for `item.i_name VARCHAR(24) + NUL` — only the destination row was mis-sized.

## Why it worked on Ubuntu 14.04 / MySQL 5.x

1. No FORTIFY in the binary. Ubuntu 14.04’s GCC 4.8.4 does not inject `_FORTIFY_SOURCE`, so `strncpy` resolves to plain libc — no runtime bounds check.
2. Benign stack layout. The stray byte lands inside the next local, `char bg[MAX_NUM_ITEMS]`, which is overwritten moments later.
3. Stack canary untouched. The 1-byte spill never reaches the canary.
4. MySQL version is irrelevant; `strncpy` always writes 25 bytes.

## Why it aborts on Ubuntu 24.04 / MySQL 8.x

1. Distro-default FORTIFY=3. Ubuntu 24.04’s GCC 13 injects `-D_FORTIFY_SOURCE=3` with optimization flags.
2. `strncpy` is rewritten to `__strncpy_chk`. The compiler emits:
   ```
   __strncpy_chk(dst, src, 25, 24)
   ```
3. At runtime, `__strncpy_chk` sees `n` (25) > `dst_size` (24) and aborts with "*** buffer overflow detected ***".
4. The abort appears right after RAMP-UP TIME, with no transaction output in between.


After this change the destination row size now matches the `n` passed to `strncpy`, so `__strncpy_chk(dst, src, 25, 25)` passes its bounds check.

This change ensures the destination buffer is correctly sized, fixing the FORTIFY-detected overflow on modern toolchains.

## Test Plan

https://fastduck.internal.memcompute.com/run/7a5ccd6ef55e43d8939ff854b6616e09/tests/all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A small constant change that slightly increases a stack buffer to match an existing `strncpy` length; minimal behavioral impact beyond preventing a runtime abort.
> 
> **Overview**
> Fixes a 1-byte buffer overflow in the New-Order transaction by increasing `MAX_ITEM_LEN` from 24 to 25 so `iname[MAX_NUM_ITEMS][MAX_ITEM_LEN]` can safely hold `i_name[25]` copied via `strncpy(..., 25)`.
> 
> Adds a clarifying comment in `tpc.h` documenting the required size (VARCHAR(24) + NUL) and the `neword.c` copy behavior, preventing FORTIFY-triggered aborts on newer toolchains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d600f672f032cb3ac0ceb7a22d21ee4c0786dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->